### PR TITLE
feat(cache): optional config to refresh a key

### DIFF
--- a/lib/classes/cache.js
+++ b/lib/classes/cache.js
@@ -54,13 +54,25 @@ class Cache {
   }
 
   async get(key, options = {}) {
-    const { producer, returnEarlyFromCache, overrideCache } = options;
+    const {
+      producer,
+      returnEarlyFromCache,
+      overrideCache,
+      shouldRefreshKey,
+    } = options;
 
-    let value = await this.rawGet(key);
+    const valuePromise = this.rawGet(key);
+    const ttl = await this.rawPTTL(key);
+    let value = await valuePromise;
 
-    if ((overrideCache || value === null) && producer) {
+    let willRefresh = false;
+    if (typeof shouldRefreshKey === 'function') {
+      willRefresh = shouldRefreshKey({ key, ttl, options });
+    }
+
+    if ((willRefresh || overrideCache || value === null) && producer) {
       const promise = this.produce(key, options);
-      if (returnEarlyFromCache) {
+      if (returnEarlyFromCache || willRefresh) {
         promise.catch((error) => this.handleAsyncProducerError(error, key, options));
       } else {
         value = await promise;
@@ -81,13 +93,13 @@ class Cache {
     return this.rawSet(...args);
   }
 
-  async rawGet(...args) {
+  async rawGet(key) {
     const start = process.hrtime();
     const { name } = this.options;
 
     let value;
     try {
-      value = await this.redis.get(...args);
+      value = await this.redis.get(key);
     } finally {
       const elapsedTime = Cache.calculateElapsedMilliseconds(start);
 
@@ -111,6 +123,18 @@ class Cache {
 
       this.rta.emitCacheOperation(name, 'set');
       this.rta.emitCacheRT(name, 'set', elapsedTime);
+    }
+    return result;
+  }
+
+  async rawPTTL(key) {
+    const { name } = this.options;
+
+    let result;
+    try {
+      result = this.redis.pttl(key);
+    } finally {
+      this.rta.emitCacheOperation(name, 'pttl');
     }
     return result;
   }


### PR DESCRIPTION
if the shouldRefreshKey option is provided as a funcion, it will be called with
the key, current key ttl, and cache.get options. And if it returns truthy, a
cache refresh (producer -> redis set) should be performed in background

closes #9